### PR TITLE
Track "starting" and "stopping" instance statuses

### DIFF
--- a/packages/lxd_toolbox/lib/instances/instance_view.dart
+++ b/packages/lxd_toolbox/lib/instances/instance_view.dart
@@ -128,11 +128,13 @@ class _InstanceListTileState extends State<_InstanceListTile> {
       leading: ProductLogo.asset(name: instance?.imageName, size: 48),
       title: Text(instance?.name ?? ''),
       subtitle: Text(instance?.imageDescription ?? ''),
-      trailing: canStop
-          ? _StopButton(widget.onStop!)
-          : canDelete
-              ? _DeleteButton(widget.onDelete!)
-              : null,
+      trailing: instance?.isBusy == true
+          ? _BusyButton()
+          : canStop
+              ? _StopButton(widget.onStop!)
+              : canDelete
+                  ? _DeleteButton(widget.onDelete!)
+                  : null,
       onTap: widget.onSelect,
     );
   }
@@ -156,4 +158,17 @@ class _StopButton extends _IconButton {
 class _DeleteButton extends _IconButton {
   const _DeleteButton(VoidCallback onPressed)
       : super(icon: const Icon(Icons.close), onPressed: onPressed);
+}
+
+class _BusyButton extends IconButton {
+  _BusyButton()
+      : super(
+          icon: const SizedBox.square(
+            dimension: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          splashColor: Colors.transparent,
+          hoverColor: Colors.transparent,
+          onPressed: () {}, // block
+        );
 }

--- a/packages/lxd_x/lib/lxd_x.dart
+++ b/packages/lxd_x/lib/lxd_x.dart
@@ -57,8 +57,11 @@ extension LxdEventX on LxdEvent {
 }
 
 extension LxdInstanceX on LxdInstance {
+  bool get isBusy => isStarting || isStopping;
+  bool get isStarting => statusCode == LxdStatusCode.starting.value;
   bool get isStarted => statusCode == LxdStatusCode.started.value;
   bool get isRunning => statusCode == LxdStatusCode.running.value;
+  bool get isStopping => statusCode == LxdStatusCode.stopping.value;
   bool get isStopped => statusCode == LxdStatusCode.stopped.value;
 }
 
@@ -83,4 +86,7 @@ extension LxdNetworkStateX on LxdNetworkState {
 extension LxdOperationX on LxdOperation {
   List<String>? get instances =>
       resources?['instances']?.map((path) => path.split('/').last).toList();
+
+  bool get isRunning => statusCode == LxdStatusCode.running.value;
+  bool get isPending => statusCode == LxdStatusCode.pending.value;
 }


### PR DESCRIPTION
Based on the stream of operation events that have textual descriptions
such as "Starting instance" and "Stopping instance". A better way is
being discussed at lxd/lxd#10625.